### PR TITLE
fix: skips vanity import when applied directory to internal module.

### DIFF
--- a/import.go
+++ b/import.go
@@ -61,12 +61,13 @@ func addImportPath(absFilepath string, module string) (bool, []byte, error) {
 	return !bytes.Equal(content, newContent), newContent, nil
 }
 
-func isInternalModule(moduleName string) bool {
-	return strings.Contains(moduleName, "/internal/") || strings.HasSuffix(moduleName, "/internal")
+func isUnexporterModule(moduleName string) bool {
+	return strings.Contains(moduleName, "/internal/") ||
+		strings.HasSuffix(moduleName, "/internal")
 }
 
 func findAndAddVanityImportForModuleDir(workingDir, absDir string, moduleName string, opts Options) (int, error) {
-	if isInternalModule(moduleName) {
+	if isUnexporterModule(moduleName) {
 		return 0, nil
 	}
 

--- a/import.go
+++ b/import.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -60,7 +61,15 @@ func addImportPath(absFilepath string, module string) (bool, []byte, error) {
 	return !bytes.Equal(content, newContent), newContent, nil
 }
 
+func isInternalModule(moduleName string) bool {
+	return strings.Contains(moduleName, "/internal/") || strings.HasSuffix(moduleName, "/internal")
+}
+
 func findAndAddVanityImportForModuleDir(workingDir, absDir string, moduleName string, opts Options) (int, error) {
+	if isInternalModule(moduleName) {
+		return 0, nil
+	}
+
 	files, err := ioutil.ReadDir(absDir)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read the content of %q: %v", absDir, err)

--- a/import_test.go
+++ b/import_test.go
@@ -81,3 +81,9 @@ func TestIsIgnoredFile(t *testing.T) {
 		),
 	)
 }
+
+func TestIsInternalModule(t *testing.T) {
+	assert.True(t, isInternalModule("go.opentelemetry.io/otel/internal"))
+	assert.True(t, isInternalModule("go.opentelemetry.io/otel/internal/metric"))
+	assert.False(t, isInternalModule("go.opentelemetry.io/otel/internalmetric"))
+}

--- a/import_test.go
+++ b/import_test.go
@@ -82,8 +82,8 @@ func TestIsIgnoredFile(t *testing.T) {
 	)
 }
 
-func TestIsInternalModule(t *testing.T) {
-	assert.True(t, isInternalModule("go.opentelemetry.io/otel/internal"))
-	assert.True(t, isInternalModule("go.opentelemetry.io/otel/internal/metric"))
-	assert.False(t, isInternalModule("go.opentelemetry.io/otel/internalmetric"))
+func TestIsUnexporterModule(t *testing.T) {
+	assert.True(t, isUnexporterModule("go.opentelemetry.io/otel/internal"))
+	assert.True(t, isUnexporterModule("go.opentelemetry.io/otel/internal/metric"))
+	assert.False(t, isUnexporterModule("go.opentelemetry.io/otel/internalmetric"))
 }


### PR DESCRIPTION
This PR skips adding vanity import for internal modules, currently running `porto -w ./something/internal/mymodule` still adds the vanity import although this is an `internal` module.

Comes from https://github.com/open-telemetry/opentelemetry-go/pull/2255/checks?check_run_id=3723701674#step:9:14