### PR TITLE
Fix error message on incorrect regexp

### DIFF
--- a/cmd/porto/main.go
+++ b/cmd/porto/main.go
@@ -6,26 +6,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/jcchavezs/porto"
 )
-
-func getRegexpList(regexps string) ([]*regexp.Regexp, error) {
-	var regexes []*regexp.Regexp
-	if len(regexps) > 0 {
-		for _, sfrp := range strings.Split(regexps, ",") {
-			sfr, err := regexp.Compile(sfrp)
-			if err != nil {
-				return nil, fmt.Errorf("failed to compile regex %q: %w", sfr, err)
-			}
-			regexes = append(regexes, sfr)
-		}
-	}
-
-	return regexes, nil
-}
 
 func main() {
 	flagWriteOutputToFile := flag.Bool("w", false, "write result to (source) file instead of stdout")
@@ -63,7 +46,7 @@ Add import path to a folder
 		log.Fatalf("failed to resolve base absolute path for current working dir: %v", err)
 	}
 
-	skipFilesRegex, err := getRegexpList(*flagSkipFiles)
+	skipFilesRegex, err := porto.GetRegexpList(*flagSkipFiles)
 	if err != nil {
 		log.Fatalf("failed to build files regexes: %v", err)
 	}

--- a/regexes.go
+++ b/regexes.go
@@ -1,0 +1,22 @@
+package porto
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func GetRegexpList(regexps string) ([]*regexp.Regexp, error) {
+	var regexes []*regexp.Regexp
+	if len(regexps) > 0 {
+		for _, sfrp := range strings.Split(regexps, ",") {
+			sfr, err := regexp.Compile(sfrp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to compile regex %q: %w", sfrp, err)
+			}
+			regexes = append(regexes, sfr)
+		}
+	}
+
+	return regexes, nil
+}

--- a/regexes_test.go
+++ b/regexes_test.go
@@ -1,0 +1,44 @@
+package porto
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRegexpList(t *testing.T) {
+	tests := []struct {
+		name     string
+		regexps  string
+		expected []*regexp.Regexp
+		err      string
+	}{
+		{
+			name:     "single regex",
+			regexps:  "^.*pb.go$",
+			expected: []*regexp.Regexp{regexp.MustCompile("^.*pb.go$")},
+		},
+		{
+			name:    "failing regex",
+			regexps: "^.*pb.go$,*$$",
+			err:     "failed to compile regex \"*$$\": error parsing regexp: missing argument to repetition operator: `*`",
+		},
+		{
+			name:     "multiple regexes",
+			regexps:  "^.*pb.go$,^tools.go$",
+			expected: []*regexp.Regexp{regexp.MustCompile("^.*pb.go$"), regexp.MustCompile("^tools.go$")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := GetRegexpList(tt.regexps)
+			if err != nil || tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Move regex list creation code to separate function (to be used on #13 impl)
- Fix error message when compiling a regex
