### PR TITLE
Covers skip dir

### DIFF
--- a/cmd/porto/main.go
+++ b/cmd/porto/main.go
@@ -18,7 +18,7 @@ func main() {
 	flagSkipDirs := flag.String("skip-dirs", "", "Regexps of directories to skip")
 	flagSkipDefaultDirs := flag.Bool("skip-dirs-use-default", true, "Use default skip directory list")
 	flagIncludeInternal := flag.Bool("include-internal", false, "Include internal folders")
-	flagRestrictToFiles := flag.String("restrict-to-files", "", "Regexps of files to restrict the inspection on. It takes precedence over -skip-files and -skip-dirs")
+	flagRestrictToFiles := flag.String("restrict-to-files", "", "Regexps of files to restrict the inspection on. It takes precedence over -skip-files")
 	flag.Parse()
 
 	baseDir := flag.Arg(0)
@@ -54,7 +54,7 @@ Add import path to a folder
 		log.Fatalf("failed to build files regexes to include: %v", err)
 	}
 
-	var skipDirsRegex []*regexp.Regexp
+	var skipDirsRegex = []*regexp.Regexp{}
 	if *flagSkipDefaultDirs {
 		skipDirsRegex = append(skipDirsRegex, porto.StdExcludeDirRegexps...)
 	}
@@ -68,13 +68,13 @@ Add import path to a folder
 		WriteResultToFile: *flagWriteOutputToFile,
 		ListDiffFiles:     *flagListDiff,
 		IncludeInternal:   *flagIncludeInternal,
+		SkipDirsRegexes:   skipDirsRegex,
 	}
 
 	if len(restrictToFilesRegex) > 0 {
 		opts.RestrictToFilesRegexes = restrictToFilesRegex
 	} else {
 		opts.SkipFilesRegexes = skipFilesRegex
-		opts.SkipDirsRegexes = skipDirsRegex
 	}
 
 	diffCount, err := porto.FindAndAddVanityImportForDir(workingDir, baseAbsDir, opts)

--- a/import.go
+++ b/import.go
@@ -106,7 +106,11 @@ func findAndAddVanityImportForModuleDir(workingDir, absDir string, moduleName st
 
 	gc := 0
 	for _, f := range files {
-		if isDir, dirName := f.IsDir(), f.Name(); isDir && !matchesAny(opts.SkipDirsRegexes, dirName) {
+		if isDir, dirName := f.IsDir(), f.Name(); isDir {
+			if matchesAny(opts.SkipDirsRegexes, dirName) {
+				continue
+			}
+
 			var (
 				c   int
 				err error

--- a/import_test.go
+++ b/import_test.go
@@ -87,14 +87,33 @@ func TestFindFilesWithVanityImport(t *testing.T) {
 		assert.Equal(t, 1, c)
 	})
 
-	t.Run("include file", func(t *testing.T) {
+	t.Run("skip dir", func(t *testing.T) {
+		c, err := findAndAddVanityImportForModuleDir(
+			cwd,
+			cwd+"/testdata",
+			"github.com/jcchavezs/porto/integration",
+			Options{
+				ListDiffFiles: true,
+				SkipDirsRegexes: []*regexp.Regexp{
+					regexp.MustCompile(`^codegen$`),
+					regexp.MustCompile(`^leftpad$`),
+					regexp.MustCompile(`^rightpad$`),
+				},
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, c)
+	})
+
+	t.Run("restrict to files", func(t *testing.T) {
 		c, err := findAndAddVanityImportForModuleDir(
 			cwd,
 			cwd+"/testdata/leftpad",
 			"github.com/jcchavezs/porto-integration-leftpad",
 			Options{
 				ListDiffFiles:          true,
-				RestrictToFilesRegexes: []*regexp.Regexp{regexp.MustCompile(`other\.go`)},
+				RestrictToFilesRegexes: []*regexp.Regexp{regexp.MustCompile(`^other\.go$`)},
 			},
 		)
 


### PR DESCRIPTION
Fixes the assignation of `skip-dirs` when `restrict-to-files` is passed.